### PR TITLE
fix: Keep the username directory permission at 750.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+shadow (1:4.14+dfsg1-0deepin4) unstable; urgency=medium
+
+  * fix: Keep the username directory permission at 750. (pms: 282975).
+
+ -- liujianqiang <liujianqiang@uniontech.com>  Wed, 11 Dec 2024 11:28:47 +0800
+
 shadow (1:4.14+dfsg1-0deepin3) unstable; urgency=medium
 
   * Use --enable-logind=yes --enable-lastlog configure flag

--- a/debian/login.defs
+++ b/debian/login.defs
@@ -153,7 +153,7 @@ UMASK		022
 # HOME_MODE is used by useradd(8) and newusers(8) to set the mode for new
 # home directories.
 # If HOME_MODE is not set, the value of UMASK is used to create the mode.
-#HOME_MODE	0700
+HOME_MODE	0750
 
 #
 # Password aging controls:


### PR DESCRIPTION
Keep the username directory permission at 750.
prevent other users from having access permissions

Log: Keep the username directory permission at 750.
pms: Bug-282975